### PR TITLE
Fix regex patterns in gs1-linkset-schema.json

### DIFF
--- a/gs1-linkset-schema.json
+++ b/gs1-linkset-schema.json
@@ -13,7 +13,7 @@
                     "anchor": {
                         "description": "The URL at the root of the linkset, a.k.a the link context",
                         "type": "string",
-                        "pattern": "^https?:\/\/[a-zA-z0-9./]+"
+                        "pattern": "^https?:\\/\\/[A-Za-z0-9./]+$"
                     },
                     "itemDescription": {
                         "name": "Item description",
@@ -27,7 +27,7 @@
                     }
                 },
                 "patternProperties": {
-                    "(?!(anchor|itemDescription|description))^([a-z-]+$)|(^https?:\/\/[a-zA-z0-9./]+$)": {
+                    "^(?!(anchor|itemDescription|description)$)([a-z-]+$|https?:\\/\\/[A-Za-z0-9./]+$)": {
                         "title": "Link object schema",
                         "description": "The schema for each link context object for each link relation",
                         "type": "array",
@@ -38,7 +38,7 @@
                                     "name": "href",
                                     "description": "The target URL",
                                     "type": "string",
-                                    "pattern": "^https?:\/\/[a-zA-z0-9./]+"
+                                    "pattern": "^https?:\\/\\/[A-Za-z0-9./]+$"
                                 },
                                 "title": {
                                     "title": "title",
@@ -51,7 +51,7 @@
                                     "type": "array",
                                     "items": {
                                         "type": "string",
-                                        "pattern": "(^\\w{2}$)|(^\\w{2}-\\w{2}$)"
+                                        "pattern": "^[A-Za-z]{2}(-[A-Za-z]{2})?$"
                                     }
                                 },
                                 "type": {
@@ -63,7 +63,10 @@
                                   "context": {
                                     "name":"Context",
                                     "description":"Any additional descriptor for the link, typically a geography or jurisdiction in which the link applies",
-                                    "type":"array"
+                                    "type":"array",
+                                      "items": {
+                                        "type": "string"
+                                      }
                                   },
                                   "fwqs" : {
                                     "name":"Forward query strings",


### PR DESCRIPTION
1. URL patterns (anchor, href, relation keys)

In the schema, URL validation uses this pattern:"^https?://[a-zA-z0-9./]+" Two things caught my attention:
1.      The range A-z unintentionally includes characters like [\]^_ in ASCII.
2.      There is no end-of-string anchor ($), so strings like https://example bad may still match

A more precise version might be:  ^https?:\/\/[A-Za-z0-9./]+$

This is not blocking, but I wanted to confirm whether the current pattern is intentional.

2. patternProperties logic (relation type names)

The schema excludes some property names using this pattern: (?!(anchor|itemDescription|description))^([a-z-]+$)|(^https?:\/\/[a-zA-z0-9./]+$)

Because the negative look-ahead uses (?!(anchor|...)) without anchoring to the full token, it also excludes any key starting with those strings (e.g., anchor-meta, description-fr), even though RFC 9264 permits extension relation types freely.

If the intent is to exclude only the exact property names, something like this might be safer: ^(?!(anchor|itemDescription|description)$)([a-z-]+$|https?:\/\/[A-Za-z0-9./]+$)

I am trying to understand whether the current behavior is deliberate.


3. The context field is under-specified

The schema currently defines: "context": { "type": "array" } There is no indication of what each item should contain (strings? objects? anything?). If the intention is to allow free-form values, then this is perfectly fine. If not, perhaps the items should be typed as strings? For example:

"context": {
  "type": "array",
  "items": { "type": "string" }
}

Just wanted to confirm the expected design here